### PR TITLE
JEV-12-S3-listener-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,137 @@
 [![Coverage Status](https://coveralls.io/repos/github/janis-commerce/s3-listener/badge.svg?branch=master)](https://coveralls.io/github/janis-commerce/s3-listener?branch=master)
 
 A package to handle the s3 event
+
+## Installation
+
+```sh
+npm install @janiscommerce/s3-listener
+```
+
+## Configuration
+
+If you are working with serverless framework and want to use the serverless-s3-local plugin you need to config the enviroment variable S3_LOCAL_ENDPOINT
+
+``` yml
+provider:
+  environment:
+    S3_LOCAL_ENDPOINT: http://localhost:{serverless-s3-local-port}
+
+```
+
+``` yml
+provider:
+  environment:
+    S3_LOCAL_ENDPOINT: http://localhost:30232
+
+custom: 
+  s3:
+    port: 30232
+    directory: ./tmp
+
+```
+
+## S3Listener
+
+This is the class you should extend to code your own Listeners. You can customize them with the following methods and getters:
+
+### async process()
+This method is required, and should have the logic of your Listener.
+
+The following methods will be inherited from the base Listener Class:
+
+### async getData()
+This method should return the data inside the S3 file (object) who generates the S3 event. 
+
+### Getters
+
+* **bucketName** (*getter*).
+Returns the name of the S3 bucket where the event is generated
+
+* **fileKey** (*getter*).
+Returns the key of the S3 object (file). This fileKey prop returns the filePrefix + filename + fileExtentions
+
+* **filename** (*getter*).
+Returns the name of the file (S3 object).
+
+* **filePrefix** (*getter*).
+Returns the prefix of the file (S3 object).
+
+* **fileExtention** (*getter*).
+Returns the extention of the file (S3 object).
+
+* **filesize** (*getter*).
+Returns the size of the file (S3 object).
+
+* **fileTag** (*getter*).
+Returns the eTag of the file (S3 object).
+
+## ServerlessHandler
+
+This is the class you should use as a handler for your AWS Lambda functions.
+
+### async handle(Listener, event, context, callback)
+This will handle the lambda execution.
+* Listener {Class} The event listener class. It's recommended to extend from this package `EventListener` class.
+* event {object} The lambda event object
+* context {object} The lambda context object
+* callback {function} The lambda callback function
+
+## ServerlessHandlerError
+
+Handled errors of the S3 Event or runtime errors inside process. If the error was emit on the process method you might find more information about the error source in the `previousError` property.
+
+It also uses the following error codes:
+
+| Name | Value | Description |
+| --- | --- | --- |
+| INVALID_EVENT | 1 | The s3 event is empty or invalid |
+| INVALID_RECORDS | 2 | The Records of the event are empty or invalid |
+| INVALID_S3_RECORD | 3 | The S3 Records of the event are empty or invalid |
+| PROCESS_NOT_FOUND | 4 | The process method is not implemented in the event listener class |
+| INTERNAL_ERROR | 5 | Errors generated in the event listener class process method |
+
+## Examples
+
+### Basic Listener
+
+```js
+'use strict';
+
+const {
+	S3Listener,
+	ServerlessHandler
+} = require('@janiscommerce/s3-listener');
+
+class MyS3EventListener extends S3Listener {
+
+	async process() {
+		/* ... Your code to process the s3 event was here ... */
+	}
+
+}
+
+module.exports.handler = (...args) => ServerlessHandler.handle(MyS3EventListener, ...args);
+```
+
+### Get Data
+
+```js
+'use strict';
+
+const {
+	S3Listener,
+	ServerlessHandler
+} = require('@janiscommerce/s3-listener');
+
+class MyS3EventListener extends S3Listener {
+
+	async process() {
+		const data = await this.getData();
+		/* ... Your code to process the s3 event was here ... */
+	}
+
+}
+
+module.exports.handler = (...args) => ServerlessHandler.handle(MyS3EventListener, ...args);
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const S3Listener = require('./s3-listener');
+const ServerlessHandler = require('./serverless/handler');
 
 module.exports = {
-	S3Listener
+	S3Listener,
+	ServerlessHandler
 };

--- a/lib/s3-listener.js
+++ b/lib/s3-listener.js
@@ -1,6 +1,93 @@
 'use strict';
 
+const S3 = require('./s3');
+
 class S3Listener {
+
+	constructor(event) {
+		this._event = event;
+	}
+
+	/**
+	 * Get the s3 bucket name
+	 *
+	 * @readonly
+	 * @memberof S3Listener
+	 */
+	get bucketName() {
+		return this._event.bucketName;
+	}
+
+	/**
+	 * Get the s3 object (file) key
+	 *
+	 * @readonly
+	 * @memberof S3Listener
+	 */
+	get fileKey() {
+		return this._event.fileKey;
+	}
+
+	/**
+	 * Get the s3 object (file) name
+	 *
+	 * @readonly
+	 * @memberof S3Listener
+	 */
+	get filename() {
+		return this._event.filename;
+	}
+
+	/**
+	 * Get the s3 object (file) prefix
+	 *
+	 * @readonly
+	 * @memberof S3Listener
+	 */
+	get filePrefix() {
+		return this._event.filePrefix;
+	}
+
+	/**
+	 * Get the s3 object (file) extention
+	 *
+	 * @readonly
+	 * @memberof S3Listener
+	 */
+	get fileExtention() {
+		return this._event.fileExtention;
+	}
+
+	/**
+	 * Get the s3 object (file) size
+	 *
+	 * @readonly
+	 * @memberof S3Listener
+	 */
+	get filesize() {
+		return this._event.filesize;
+	}
+
+	/**
+	 * Get the s3 object (file) md5 tag
+	 *
+	 * @readonly
+	 * @memberof S3Listener
+	 */
+	get fileTag() {
+		return this._event.fileTag;
+	}
+
+	/**
+	 * Get the S3 file data
+	 *
+	 * @returns
+	 * @memberof S3Listener
+	 */
+	async getData() {
+		const { Body } = await S3.get({ Bucket: this.bucketName, Key: this.fileKey });
+		return this.fileExtention === 'json' ? JSON.parse(Body.toString('utf8')) : Body;
+	}
 }
 
 module.exports = S3Listener;

--- a/lib/s3/index.js
+++ b/lib/s3/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const S3Wrapper = require('./wrapper');
+
+exports.get = (...args) => {
+	return S3Wrapper
+		.getObject(...args)
+		.promise();
+};

--- a/lib/s3/wrapper.js
+++ b/lib/s3/wrapper.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { S3, Endpoint } = require('aws-sdk');
+
+const { IS_OFFLINE, S3_LOCAL_ENDPOINT } = process.env;
+
+const localConfig = {
+	s3ForcePathStyle: true,
+	endpoint: S3_LOCAL_ENDPOINT ? /* istanbul ignore next */ new Endpoint(S3_LOCAL_ENDPOINT) : null,
+	accessKeyId: 'S3RVER',
+	secretAccessKey: 'S3RVER'
+};
+
+// Use the ignore because cannot change that process env globally
+module.exports = IS_OFFLINE && S3_LOCAL_ENDPOINT ? /* istanbul ignore next */ new S3(localConfig) : new S3();

--- a/lib/serverless/dispatcher.js
+++ b/lib/serverless/dispatcher.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const ServerlessHandlerError = require('./error');
+
+const isObject = value => typeof value === 'object' && !Array.isArray(value);
+
+class ServerlessDispatcher {
+
+	/**
+	 * Dispatch the event to the listener package
+	 *
+	 * @static
+	 * @param {*} Listener
+	 * @param {*} event
+	 * @memberof ServerlessDispatcher
+	 */
+	static async dispatch(Listener, event) {
+
+		if(typeof event !== 'object' || !Object.keys(event).length)
+			throw new ServerlessHandlerError('Event cannot be empty and must be an object', ServerlessHandlerError.codes.INVALID_EVENT);
+
+		this.s3Event = event;
+
+		const listener = new Listener(this.event);
+
+		if(typeof listener.process !== 'function')
+			throw new ServerlessHandlerError('Process method is required and must be a function', ServerlessHandlerError.codes.PROCESS_NOT_FOUND);
+
+		try {
+			await listener.process();
+		} catch(err) {
+			throw new ServerlessHandlerError(err, ServerlessHandlerError.codes.INTERNAL_ERROR);
+		}
+	}
+
+	/**
+	 * Get the S3 event
+	 *
+	 * @static
+	 * @memberof ServerlessDispatcher
+	 */
+	static get s3Event() {
+		return this._s3Event;
+	}
+
+	/**
+	 * Set the S3 event
+	 *
+	 * @static
+	 * @memberof ServerlessDispatcher
+	 */
+	static set s3Event({ Records }) {
+
+		if(!Array.isArray(Records) || !Records.length)
+			throw new ServerlessHandlerError('Event Records cannot be empty and must be an array', ServerlessHandlerError.codes.INVALID_RECORDS);
+
+		const { s3: s3Event } = Records[0];
+		if(!isObject(s3Event) || !isObject(s3Event.bucket) || !isObject(s3Event.object))
+			throw new ServerlessHandlerError('Cannot get the S3 event from Records', ServerlessHandlerError.codes.INVALID_S3_RECORD);
+
+		this._s3Event = s3Event;
+	}
+
+	/**
+	 * Get the S3 event
+	 *
+	 * @static
+	 * @memberof ServerlessDispatcher
+	 */
+	static get event() {
+
+		const { bucketName, fileKey, filesize, fileTag } = this;
+
+		const keyParts = fileKey.split('/');
+		const [filename, fileExtention] = keyParts.pop().split('.');
+		const filePrefix = keyParts.join('/');
+
+		return {
+			bucketName,
+			fileKey,
+			filename,
+			filePrefix,
+			fileExtention,
+			filesize,
+			fileTag
+		};
+	}
+
+	/**
+	 * Get the event bucket name
+	 *
+	 * @readonly
+	 * @static
+	 * @memberof ServerlessDispatcher
+	 */
+	static get bucketName() {
+		return this.s3Event.bucket.name;
+	}
+
+	/**
+	 * Get the s3 event key
+	 *
+	 * @readonly
+	 * @static
+	 * @memberof ServerlessDispatcher
+	 */
+	static get fileKey() {
+		return this.s3Event.object.key;
+	}
+
+	/**
+	 * Get the s3 event size
+	 *
+	 * @readonly
+	 * @static
+	 * @memberof ServerlessDispatcher
+	 */
+	static get filesize() {
+		return this.s3Event.object.size;
+	}
+
+	/**
+	 * Get the s3 event eTag
+	 *
+	 * @readonly
+	 * @static
+	 * @memberof ServerlessDispatcher
+	 */
+	static get fileTag() {
+		return this.s3Event.object.eTag;
+	}
+}
+
+module.exports = ServerlessDispatcher;

--- a/lib/serverless/error.js
+++ b/lib/serverless/error.js
@@ -1,0 +1,34 @@
+'use strict';
+
+class ServerlessHandlerError extends Error {
+
+	constructor(err, code) {
+
+		super(err.message || err);
+
+		this.name = 'ServerlessHandlerError';
+		this.code = code;
+
+		if(typeof err !== 'string')
+			this.previousError = err;
+	}
+
+	/**
+	 * Serverless error codes
+	 *
+	 * @readonly
+	 * @static
+	 * @memberof ServerlessHandlerError
+	 */
+	static get codes() {
+		return {
+			INVALID_EVENT: 1,
+			INVALID_RECORDS: 2,
+			INVALID_S3_RECORD: 3,
+			PROCESS_NOT_FOUND: 4,
+			INTERNAL_ERROR: 5
+		};
+	}
+}
+
+module.exports = ServerlessHandlerError;

--- a/lib/serverless/handler.js
+++ b/lib/serverless/handler.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const ServerlessDispatcher = require('./dispatcher');
+
+/**
+ * The Serverless S3 event listener
+ *
+ * @param {ObjectConstructor} Listener The listener class
+ * @param {Object} event The event class
+ */
+module.exports.handle = (Listener, event) => ServerlessDispatcher.dispatch(Listener, event);

--- a/package-lock.json
+++ b/package-lock.json
@@ -252,11 +252,32 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.556.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.556.0.tgz",
+      "integrity": "sha512-qILMUNl/a7FYWU67Y24OGsXFhyDHM4qYdplMR2tps/g17pN9bEQ5ijxvGzW2T8VVyAsTanmn+dFyl/CH38pC5Q==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -273,6 +294,16 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
     },
     "caching-transform": {
       "version": "3.0.2",
@@ -882,6 +913,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -1326,6 +1362,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1469,8 +1510,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1559,6 +1599,11 @@
       "requires": {
         "handlebars": "^4.1.2"
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2335,10 +2380,14 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -2457,6 +2506,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
       "version": "6.3.0",
@@ -2895,13 +2949,29 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
       }
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-      "dev": true
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -3043,6 +3113,20 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
       }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   ],
   "directories": {
     "test": "tests"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.556.0"
   }
 }

--- a/tests/s3-listener.js
+++ b/tests/s3-listener.js
@@ -2,12 +2,69 @@
 
 const assert = require('assert');
 
+const sandbox = require('sinon').createSandbox();
+
+const S3 = require('../lib/s3');
+
 const { S3Listener } = require('../lib');
+
+const event = {
+	bucketName: 'test-bucket',
+	fileKey: 'testing/test.txt',
+	filename: 'test',
+	filePrefix: 'testing',
+	filesize: 80,
+	fileExtention: 'txt',
+	fileTag: 'f5edbddec6fc3d3a7fabe0e4c14d474b'
+};
+
+const jsonEvent = { ...event, fileKey: 'testing/test.json', fileExtention: 'json' };
 
 describe('S3 Listener Test', () => {
 
-	it('Should init the test of class', () => {
-		const s3Listener = new S3Listener();
-		assert.ok(s3Listener instanceof S3Listener);
+	beforeEach(() => {
+		this.S3 = sandbox.stub(S3, 'get');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('Should return the properties inside the event pass through', () => {
+		const s3Listener = new S3Listener(event);
+
+		assert.deepStrictEqual(s3Listener.bucketName, event.bucketName);
+		assert.deepStrictEqual(s3Listener.fileKey, event.fileKey);
+		assert.deepStrictEqual(s3Listener.filename, event.filename);
+		assert.deepStrictEqual(s3Listener.filePrefix, event.filePrefix);
+		assert.deepStrictEqual(s3Listener.filesize, event.filesize);
+		assert.deepStrictEqual(s3Listener.fileExtention, event.fileExtention);
+		assert.deepStrictEqual(s3Listener.fileTag, event.fileTag);
+	});
+
+	it('Should return the S3 data', async () => {
+		const body = 'This is a testing data';
+		this.S3.returns(Promise.resolve({ Body: body }));
+
+		const s3Listener = new S3Listener(event);
+		const getData = await s3Listener.getData();
+
+		assert.deepStrictEqual(getData, body);
+
+		sandbox.assert.calledOnce(S3.get);
+		sandbox.assert.calledWithExactly(S3.get, { Bucket: event.bucketName, Key: event.fileKey });
+	});
+
+	it('Should return the S3 JSON data', async () => {
+		const body = { test: 'testing' };
+		this.S3.returns(Promise.resolve({ Body: JSON.stringify(body) }));
+
+		const s3Listener = new S3Listener(jsonEvent);
+		const getData = await s3Listener.getData();
+
+		assert.deepStrictEqual(getData, body);
+
+		sandbox.assert.calledOnce(S3.get);
+		sandbox.assert.calledWithExactly(S3.get, { Bucket: event.bucketName, Key: jsonEvent.fileKey });
 	});
 });

--- a/tests/s3/index.js
+++ b/tests/s3/index.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const assert = require('assert');
+
+const sandbox = require('sinon').createSandbox();
+
+const S3Wrapper = require('../../lib/s3/wrapper');
+
+const S3 = require('../../lib/s3');
+
+const s3Params = {
+	Bucket: 'test-bucket',
+	Key: 'test.json'
+};
+
+describe('S3 Wrapper Test', () => {
+
+	beforeEach(() => {
+		this.s3 = sandbox.stub(S3Wrapper, 'getObject');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('Should throw an error when S3 get object return an error', async () => {
+		const message = 'Cannot get any object with the provided key';
+		this.s3.returns({ promise: () => Promise.reject(new Error(message)) });
+
+		assert.rejects(S3.get(s3Params), {
+			name: 'Error',
+			message
+		});
+	});
+
+	it('Should return the S3 data object', async () => {
+
+		const data = JSON.stringify({ test: 'this is some testing body' });
+
+		const s3DataObject = {
+			Body: data
+		};
+		this.s3.returns({ promise: () => Promise.resolve(s3DataObject) });
+
+		const { Body } = await S3.get(s3Params);
+		assert.deepStrictEqual(Body, data);
+	});
+});

--- a/tests/serverless/handler.js
+++ b/tests/serverless/handler.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const assert = require('assert');
+
+const sandbox = require('sinon').createSandbox();
+
+const { ServerlessHandler, S3Listener } = require('../../lib');
+
+class ListenerTest extends S3Listener {
+	async process() {
+		this.setProps({ ...this });
+	}
+
+	setProps(props) {
+		this._props = props;
+	}
+}
+
+const event = {
+	Records: [
+		{
+			s3: {
+				s3SchemaVersion: '1.0',
+				configurationId: 'testConfigId',
+				bucket: {
+					name: 'janis-events-service-local',
+					ownerIdentity: { principalId: '25DF414140DB20' },
+					arn: 'arn:aws:s3: : :janis-events-service-local'
+				},
+				object: {
+					key: 'subscribers/test.json',
+					sequencer: '16E051CDD44',
+					size: 84,
+					eTag: 'f5edbddec6fc3d3a7fabe0e4c14d474b'
+				}
+			}
+		}
+	]
+};
+
+describe('Serverless Handler Test', () => {
+
+	beforeEach(() => {
+		this.listenerTestProps = sandbox.stub(ListenerTest.prototype, 'setProps');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('Should throw an error when s3 event is empty or invalid', () => {
+		assert.rejects(ServerlessHandler.handle(ListenerTest), {
+			name: 'ServerlessHandlerError',
+			code: 1,
+			message: 'Event cannot be empty and must be an object'
+		});
+
+		assert.rejects(ServerlessHandler.handle(ListenerTest, ''), {
+			name: 'ServerlessHandlerError',
+			code: 1,
+			message: 'Event cannot be empty and must be an object'
+		});
+
+		assert.rejects(ServerlessHandler.handle(ListenerTest, {}), {
+			name: 'ServerlessHandlerError',
+			code: 1,
+			message: 'Event cannot be empty and must be an object'
+		});
+	});
+
+	it('Should throw and error when event Records are empty or not an array', () => {
+		assert.rejects(ServerlessHandler.handle(ListenerTest, { Records: '' }), {
+			name: 'ServerlessHandlerError',
+			code: 2,
+			message: 'Event Records cannot be empty and must be an array'
+		});
+
+		assert.rejects(ServerlessHandler.handle(ListenerTest, { Records: [] }), {
+			name: 'ServerlessHandlerError',
+			code: 2,
+			message: 'Event Records cannot be empty and must be an array'
+		});
+	});
+
+	it('Should throw an error when records does not have an s3 object or is invalid', () => {
+		assert.rejects(ServerlessHandler.handle(ListenerTest, { Records: [{}] }), {
+			name: 'ServerlessHandlerError',
+			code: 3,
+			message: 'Cannot get the S3 event from Records'
+		});
+
+		assert.rejects(ServerlessHandler.handle(ListenerTest, { Records: [{ s3: {} }] }), {
+			name: 'ServerlessHandlerError',
+			code: 3,
+			message: 'Cannot get the S3 event from Records'
+		});
+
+		assert.rejects(ServerlessHandler.handle(ListenerTest, { Records: [{ s3: { bucket: {} } }] }), {
+			name: 'ServerlessHandlerError',
+			code: 3,
+			message: 'Cannot get the S3 event from Records'
+		});
+
+		assert.rejects(ServerlessHandler.handle(ListenerTest, { Records: [{ s3: { object: {} } }] }), {
+			name: 'ServerlessHandlerError',
+			code: 3,
+			message: 'Cannot get the S3 event from Records'
+		});
+	});
+
+	it('Should throw an error when process is not found', () => {
+
+		const ListernerTestWithoutProcess = function() {};
+
+		assert.rejects(ServerlessHandler.handle(ListernerTestWithoutProcess, event), {
+			name: 'ServerlessHandlerError',
+			code: 4,
+			message: 'Process method is required and must be a function'
+		});
+	});
+
+	it('Should throw an error when process throws an error', () => {
+
+		const error = new Error('This is an error originated on listener process method');
+
+		const ListernerTestProcessError = function() {};
+		ListernerTestProcessError.prototype.process = async function() {
+			throw error;
+		};
+
+		assert.rejects(ServerlessHandler.handle(ListernerTestProcessError, event), {
+			name: 'ServerlessHandlerError',
+			code: 5,
+			message: 'This is an error originated on listener process method',
+			previousError: error
+		});
+	});
+
+	it('Should process the event and set the properties to listener', () => {
+
+		assert.doesNotReject(ServerlessHandler.handle(ListenerTest, event));
+
+		sandbox.assert.calledOnce(ListenerTest.prototype.setProps);
+		sandbox.assert.calledWithExactly(ListenerTest.prototype.setProps, {
+			_event: {
+				bucketName: 'janis-events-service-local',
+				fileExtention: 'json',
+				fileKey: 'subscribers/test.json',
+				filePrefix: 'subscribers',
+				fileTag: 'f5edbddec6fc3d3a7fabe0e4c14d474b',
+				filename: 'test',
+				filesize: 84
+			}
+		});
+	});
+
+});


### PR DESCRIPTION
**Link al ticket**
https://fizzmod.atlassian.net/browse/JEV-12

**Descripción del requerimiento**
Debido a la necesidad de crear handlers para los eventos de S3 en serverless se requiere crear un handler y un listener que ayude a manejar dichos eventos del S3.

**Descripción de la solución**
Se creo el package de handler y listener de eventos de S3 que facilitan el manejo de los eventos, adicional a esto se documento mediante el Readme el uso del package 

**Cómo se puede probar?**
Como el package no se encuentra operativo se debe agregar dicho package a un repo local y probar que se ejecute correctamente. Para hacer uso de este se debe hacer de la siguiente forma:

- Clonar el repo en /var/www/@janiscommerce/s3-listener, hacer `npm install` y luego `npm link `
- Despues ir al repositorio en el cual se vaya a probar y hacer `npm install @janis-commerce/s3-listener`
- Agregar el package al volumen de docker en el docker-compose.yml  `- /var/www/@janiscommerce/s3-listener:/var/www/janis/node_modules/@janiscommerce/s3-listener`
- Una vez hecho esto se debe crear una función lambda que escuche el evento S3 bajo la documentación del mismo y probar que se ejecute de la forma esperada.

**Screenshots**
No.

**Datos extra a tener en cuenta**
No.

**Changelog**
Added:
- Initial package version
- Unit tests